### PR TITLE
delete also if 99-default.link is a symbolic link

### DIFF
--- a/install
+++ b/install
@@ -385,7 +385,7 @@ fi
 # remove networkmanager and dhcpcd5 then configure networkd
 if [ ${version} -gt 4 ]; then
   defLink="/etc/systemd/network/99-default.link"
-  if [ -f "${defLink}" ]; then
+  if [ -f "${defLink}" || -L "${defLink}" ]; then
     rm -f "${defLink}"
   fi
   nic="eth0"


### PR DESCRIPTION
Closes https://github.com/openmediavault/openmediavault/issues/682 and closes https://github.com/openmediavault/openmediavault/issues/683

In Raspbian Buster 2020-02-13, the file is a symbolic link to /dev/null and is not detected correctly with the -f condition