### PR TITLE
additional locale settings

### DIFF
--- a/install
+++ b/install
@@ -79,6 +79,8 @@ wpaConf="/etc/wpa_supplicant/wpa_supplicant.conf"
 export DEBIAN_FRONTEND=noninteractive
 export APT_LISTCHANGES_FRONTEND=none
 export LANG=C.UTF-8
+export LANGUAGE=C
+export LC_ALL=C.UTF-8
 
 if [ -f /etc/armbian-release ]; then
   . /etc/armbian-release


### PR DESCRIPTION
Sometimes people use `LANGUAGE` to select a different language environment.

To prevent other Locale settings, set `LC_ALL` to complete the override.