### PR TITLE
Update install

### DIFF
--- a/install
+++ b/install
@@ -153,6 +153,9 @@ apt-get --allow-releaseinfo-change update
 echo "Installing lsb_release..."
 apt-get --yes --no-install-recommends --reinstall install lsb-release
 
+echo "Installing apparmor-utils..."
+apt-get --yes --no-install-recommends install apparmor apparmor-utils
+
 arch="$(dpkg --print-architecture)"
 
 # exit if not supported architecture


### PR DESCRIPTION
Install apparmor-utils. 
Fix https://forum.openmediavault.org/index.php?thread/43606-can-t-run-docker-containers-after-upgrade-to-v6-apparmor-missing/&pageNo=2